### PR TITLE
Update pwt-datepicker.js

### DIFF
--- a/js/pwt-datepicker.js
+++ b/js/pwt-datepicker.js
@@ -639,7 +639,7 @@ var delay = function(callback,ms){
                               return false;
                           });
                           self.inputElem.blur(function () {
-                             if ( !$.browser.msie ) {
+                             if (!$.browser || !$.browser.msie ) {
                                     self.hide();
                              }
                           });


### PR DESCRIPTION
Add support for JQuery  1.9+ versions.
In new JQuery versions old IE supports are dropped. And all features works properly cross browser.

This change tested in IE 10 ans works properly.
