### PR TITLE
a few changes to make it webpack friendly!

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
-    "jquery": "^2.2.0",
+    "jquery": "^3.3.1",
     "persian-date": "^1.0.4"
   },
   "pre-commit": [

--- a/src/es6/index.js
+++ b/src/es6/index.js
@@ -4,28 +4,26 @@ let Model = require('./model');
  * @author babakhani.reza@gmail.com
  * @description jquery plugin initializer
  */
-(function ($) {
-    /*eslint-disable no-unused-vars */
-    $.fn.persianDatepicker = $.fn.pDatepicker = function (options) {
-        let args = Array.prototype.slice.call(arguments), output = null, self = this;
-        if (!this) {
-            $.error('Invalid selector');
+/*eslint-disable no-unused-vars */
+module.exports = function (options) {
+    let args = Array.prototype.slice.call(arguments), output = null, self = this;
+    if (!this) {
+        $.error('Invalid selector');
+    }
+    $(this).each(function () {
+        // encapsulation Args
+        let emptyArr = [],
+          tempArg = args.concat(emptyArr),
+          dp = $(this).data('datepicker'),
+          funcName = null;
+        if (dp && typeof tempArg[0] === 'string') {
+            funcName = tempArg[0];
+            output = dp[funcName](tempArg[0]);
+        } else {
+            self.pDatePicker = new Model(this, options);
         }
-        $(this).each(function () {
-            // encapsulation Args
-            let emptyArr = [],
-              tempArg = args.concat(emptyArr),
-              dp = $(this).data('datepicker'),
-              funcName = null;
-            if (dp && typeof tempArg[0] === 'string') {
-                funcName = tempArg[0];
-                output = dp[funcName](tempArg[0]);
-            } else {
-                self.pDatePicker = new Model(this, options);
-            }
-        });
-        $(this).data('datepicker', self.pDatePicker);
-        return self.pDatePicker;
-    };
-    /*eslint-enable no-unused-vars */
-})(jQuery);
+    });
+    $(this).data('datepicker', self.pDatePicker);
+    return self.pDatePicker;
+};
+/*eslint-enable no-unused-vars */


### PR DESCRIPTION
I used your package in my project, it's awesome!
But when i built it with ``webpack`` i got ``$(...).pDatePicker is not a function`` error
Now with these modifications it's working great
```javascript
window.$ = window.jQuery = require('jquery'); // latest version, currently: 3.3.1
window.persianDate = require('persian-date/dist/persian-date.min');
window.$.fn.pDatePicker = require('pwt.datepicker/src/es6/index');
```
Maybe it's a good idea to update README.md if you accept my pull request, thanks.