### PR TITLE
Fix 0 keycode in input

### DIFF
--- a/src/es6/input.js
+++ b/src/es6/input.js
@@ -86,7 +86,7 @@ class Input {
         $(that.elem).bind('keyup', function (e) {
             let $self = $(this);
             let trueKey = false;
-            if (e.keyCode === 8 || e.keyCode < 105 && e.keyCode > 96 || e.keyCode < 58 && e.keyCode > 47 || (ctrlDown && (e.keyCode == vKey || $.inArray(e.keyCode, ctrlKey) > 0  ))) {
+            if (e.keyCode === 8 || e.keyCode < 105 && e.keyCode >= 96 || e.keyCode < 58 && e.keyCode > 47 || (ctrlDown && (e.keyCode == vKey || $.inArray(e.keyCode, ctrlKey) > 0  ))) {
                 trueKey = true;
             }
             if (trueKey) {


### PR DESCRIPTION
In autocomplete date after enter for example : 1401/05/10 or any dates that ends with "0" because code of "0" is 96 that statement doesn't work and nothing show.
if change it to >= 96 it's work fine.